### PR TITLE
Refactor duplicate .tile CSS class to src/app.css

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -20,3 +20,9 @@
         border-color: var(--color-gray-200, currentcolor);
     }
 }
+
+@layer components {
+    .tile {
+        @apply leading-[1.6] p-6 border-2 border-primary rounded-[10px] bg-base-200;
+    }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -54,8 +54,7 @@
 <div class="flex flex-wrap sm:flex-row">
     <a href={resolve('/')} class="flex items-center m-4">
         <img src="favicon.svg" alt="PDFCrypt" class="h-16 align-middle mx-4" />
-        <h1
-            class="text-4xl rounded-lg p-2.5 border-2 bg-primary text-white border-transparent">
+        <h1 class="text-4xl rounded-lg p-2.5 border-2 bg-primary text-white border-transparent">
             PDFCrypt
         </h1>
     </a>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -420,13 +420,3 @@
         </div>
     </div>
 </div>
-
-<style>
-    .tile {
-        line-height: 1.6;
-        padding: 1.5rem;
-        border: hsl(var(--p)) solid 2px;
-        border-radius: 10px;
-        background: hsl(var(--b2));
-    }
-</style>

--- a/src/routes/decrypt/+page.svelte
+++ b/src/routes/decrypt/+page.svelte
@@ -239,13 +239,3 @@
         </div>
     </div>
 </div>
-
-<style>
-    .tile {
-        line-height: 1.6;
-        padding: 1.5rem;
-        border: hsl(var(--p)) solid 2px;
-        border-radius: 10px;
-        background: hsl(var(--b2));
-    }
-</style>

--- a/src/routes/install/+page.svelte
+++ b/src/routes/install/+page.svelte
@@ -58,20 +58,13 @@
         <div class="tile m-4 h-fit">
             <h2 class="text-2xl rounded-lg p-2.5 bg-primary text-white mb-4 w-fit">MacOS</h2>
             <ol>
-                <li>- Open the app in Safari. If you're using a Chrome-based browser, follow the Windows instructions instead.</li>
+                <li>
+                    - Open the app in Safari. If you're using a Chrome-based browser, follow the
+                    Windows instructions instead.
+                </li>
                 <li>- Click the share button in the address bar.</li>
                 <li>- Click "Add to Dock".</li>
             </ol>
         </div>
     </div>
 </div>
-
-<style>
-    .tile {
-        line-height: 1.6;
-        padding: 1.5rem;
-        border: hsl(var(--p)) solid 2px;
-        border-radius: 10px;
-        background: hsl(var(--b2));
-    }
-</style>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,7 +1,3 @@
-<script>
-    import { resolve } from '$app/paths';
-</script>
-
 <svelte:head>
     <title>PDFCrypt - Privacy Policy</title>
 </svelte:head>
@@ -27,13 +23,3 @@
         </li>
     </ol>
 </div>
-
-<style>
-    .tile {
-        line-height: 1.6;
-        padding: 1.5rem;
-        border: hsl(var(--p)) solid 2px;
-        border-radius: 10px;
-        background: hsl(var(--b2));
-    }
-</style>


### PR DESCRIPTION
Moved the duplicate `.tile` CSS class definition from multiple Svelte components to `src/app.css` to improve code maintainability and reduce duplication. The new definition uses Tailwind CSS utility classes (`@apply`) to ensure consistent styling and compatibility with the project's theme configuration (DaisyUI). Verified visual correctness via Playwright screenshots and passed all lint/check scripts.

---
*PR created automatically by Jules for task [18336320122084568059](https://jules.google.com/task/18336320122084568059) started by @Randomblock1*